### PR TITLE
Using non-blocking send for UDP

### DIFF
--- a/application/cam/cam.cpp
+++ b/application/cam/cam.cpp
@@ -86,6 +86,11 @@ Option<BuffRefLen> Camera::getNextFrameBuff()
     return m_pic.getNextFrameBuff();
 }
 
+void Camera::setCurrentFrameProcessed()
+{
+    m_pic.setCurrentFrameProcessed();
+}
+
 uint32_t Camera::getPicLen()
 {
     return m_pic.getLen();

--- a/application/cam/cam.h
+++ b/application/cam/cam.h
@@ -94,6 +94,7 @@ public:
     bool isPicAvailable();
 
     Option<BuffRefLen> getNextFrameBuff();
+    void setCurrentFrameProcessed();
 
     uint32_t getPicLen();
 };

--- a/application/cam/picture.h
+++ b/application/cam/picture.h
@@ -101,8 +101,18 @@ struct CamPicture
     {
         if (isAvailable())
         {
-            Option<BuffRefLen> next_frame_buff_len = Option<BuffRefLen>(BuffRefLen(m_pic_frames[m_processed_frames].getBufferRef(), m_pic_frames[m_processed_frames].getLen() + FRAME_HEADER_LEN));
+            return Option<BuffRefLen>(BuffRefLen(m_pic_frames[m_processed_frames].getBufferRef(), m_pic_frames[m_processed_frames].getLen() + FRAME_HEADER_LEN));
+        }
+        else
+        {
+            return Option<BuffRefLen>();
+        }
+    }
 
+    void setCurrentFrameProcessed()
+    {
+        if (isAvailable())
+        {
             m_processed_frames += 1;
 
             if (m_processed_frames == m_stored_frames)
@@ -110,12 +120,6 @@ struct CamPicture
                 m_processed_frames = 0;
                 m_state = PictureState::Processed;
             }
-
-            return next_frame_buff_len;
-        }
-        else
-        {
-            return Option<BuffRefLen>();
         }
     }
 

--- a/application/network/clients/clients.h
+++ b/application/network/clients/clients.h
@@ -254,25 +254,12 @@ Result<int, ClientError> Clients<NbAllowedClients, MaxFrameLen>::sendUdpMsgToAll
     {
         for (int client_idx = 0; client_idx < m_nb_connected_clients; client_idx++)
         {
-            // Maybe track error & retry elsewhere
-            bool done = false;
-            while (!done)
+            Result<int, ClientError> res = sendUdpMsg(client_idx, msg_ptr, size);
+
+            if (res.isErr())
             {
-                Result<int, ClientError> res = sendUdpMsg(client_idx, msg_ptr, size);
 
-                if (res.isErr())
-                {
-                    ClientError err = res.getErr();
-
-                    if ((err != ClientError::SocketOutOfMemory) && (err != ClientError::SocketWouldBlock))
-                    {
-                        return res;
-                    }
-                }
-                else
-                {
-                    done = true;
-                }
+                return res;
             }
         }
 

--- a/core/program.cpp
+++ b/core/program.cpp
@@ -133,8 +133,14 @@ void MainProgram::updateCam()
 
                 BuffRefLen pic_frame_buff_len = opt_pic_frame_buff_len.getData();
 
-                // ESP_LOGI(LOG_TAG, "pic_frame_len=%d", pic_frame_buff_len.m_len);
-                m_wifi->tryToSendUdpMsg(pic_frame_buff_len.m_buff_ref, pic_frame_buff_len.m_len); // NetServer::MAX_MSG_SIZE); // TMP:len
+                if (m_wifi->tryToSendUdpMsg(pic_frame_buff_len.m_buff_ref, pic_frame_buff_len.m_len))
+                {
+                    m_camera.setCurrentFrameProcessed();
+                }
+                else
+                {
+                    done_sending = true;
+                }
             }
         }
     }


### PR DESCRIPTION
+ when an error occurs while sending camera's frame, we continue sending frames in the next iteration
(SocketOutOfMemory | SocketWouldBlock)